### PR TITLE
Add muP optimizer parameter groups

### DIFF
--- a/llmfoundry/models/layers/__init__.py
+++ b/llmfoundry/models/layers/__init__.py
@@ -7,6 +7,7 @@ from llmfoundry.models.layers.attention import (
     scaled_multihead_dot_product_attention, triton_flash_attn_fn)
 from llmfoundry.models.layers.blocks import MPTBlock
 from llmfoundry.models.layers.custom_embedding import SharedEmbedding
+from llmfoundry.models.layers.mup_embedding import MuPSharedEmbedding
 from llmfoundry.models.layers.fc import FC_CLASS_REGISTRY
 from llmfoundry.models.layers.ffn import FFN_CLASS_REGISTRY, MPTMLP, build_ffn
 from llmfoundry.models.layers.norm import NORM_CLASS_REGISTRY, LPLayerNorm
@@ -27,6 +28,7 @@ __all__ = [
     'LPLayerNorm',
     'FC_CLASS_REGISTRY',
     'SharedEmbedding',
+    'MuPSharedEmbedding',
     'FFN_CLASS_REGISTRY',
     'build_ffn',
 ]

--- a/llmfoundry/models/layers/mup_embedding.py
+++ b/llmfoundry/models/layers/mup_embedding.py
@@ -1,0 +1,23 @@
+from torch import Tensor
+
+from .custom_embedding import SharedEmbedding
+
+
+
+class MuPSharedEmbedding(SharedEmbedding):
+    """SharedEmbedding that scales its forward output for muP."""
+
+    def __init__(self, *args, scale: float = 1.0, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Begin muP code: store scaling factor for embedding outputs
+        self.scale = scale
+        # End muP code
+
+    def forward(self, input: Tensor, unembed: bool = False) -> Tensor:
+        out = super().forward(input, unembed)
+        if not unembed:
+            # Begin muP code: scale embedding output
+            out = out * self.scale
+            # End muP code
+        return out
+

--- a/llmfoundry/models/model_registry.py
+++ b/llmfoundry/models/model_registry.py
@@ -5,10 +5,12 @@ from llmfoundry.models.hf import (ComposerHFCausalLM, ComposerHFPrefixLM,
                                   ComposerHFT5)
 from llmfoundry.models.inference_api_wrapper import (OpenAICausalLMEvalWrapper,
                                                      OpenAIChatAPIEvalWrapper)
-from llmfoundry.models.mpt import ComposerMPTCausalLM
+from llmfoundry.models.mpt import (ComposerMPTCausalLM, MPTMuPForCausalLM,
+                                   ComposerMPTMuPCausalLM)
 
 COMPOSER_MODEL_REGISTRY = {
     'mpt_causal_lm': ComposerMPTCausalLM,
+    'mpt_mup_causal_lm': ComposerMPTMuPCausalLM,
     'hf_causal_lm': ComposerHFCausalLM,
     'hf_prefix_lm': ComposerHFPrefixLM,
     'hf_t5': ComposerHFT5,

--- a/llmfoundry/models/mpt/__init__.py
+++ b/llmfoundry/models/mpt/__init__.py
@@ -2,9 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from llmfoundry.models.mpt.configuration_mpt import MPTConfig
+from llmfoundry.models.mpt.configuration_mpt_mup import MPTMuPConfig
 from llmfoundry.models.mpt.modeling_mpt import (ComposerMPTCausalLM,
                                                 MPTForCausalLM, MPTModel,
                                                 MPTPreTrainedModel)
+from llmfoundry.models.mpt.modeling_mpt_mup import (MPTMuPModel,
+                                                    MPTMuPForCausalLM,
+                                                    ComposerMPTMuPCausalLM)
 
 __all__ = [
     'MPTPreTrainedModel',
@@ -12,4 +16,8 @@ __all__ = [
     'MPTForCausalLM',
     'ComposerMPTCausalLM',
     'MPTConfig',
+    'MPTMuPConfig',
+    'MPTMuPModel',
+    'MPTMuPForCausalLM',
+    'ComposerMPTMuPCausalLM',
 ]

--- a/llmfoundry/models/mpt/configuration_mpt_mup.py
+++ b/llmfoundry/models/mpt/configuration_mpt_mup.py
@@ -1,0 +1,46 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the muP-enabled MPT model."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .configuration_mpt import MPTConfig
+
+
+class MPTMuPConfig(MPTConfig):
+    """Extends :class:`~llmfoundry.models.mpt.configuration_mpt.MPTConfig` with muP parameters."""
+
+    model_type = 'mpt-mup'
+
+    def __init__(
+        self,
+        mup_enabled: bool = False,
+        mup_disable_attention_scaling: bool = False,
+        mup_disable_hidden_lr_scaling: bool = False,
+        mup_width_multiplier: float = 1.0,
+        mup_input_alpha: float = 1.0,
+        mup_output_alpha: float = 1.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        # Begin muP code: store muP configuration parameters
+        self.mup_enabled = mup_enabled
+        self.mup_disable_attention_scaling = mup_disable_attention_scaling
+        self.mup_disable_hidden_lr_scaling = mup_disable_hidden_lr_scaling
+        self.mup_width_multiplier = mup_width_multiplier
+        self.mup_input_alpha = mup_input_alpha
+        self.mup_output_alpha = mup_output_alpha
+        # End muP code
+
+        # if muP is enabled and attention scaling is not disabled, set softmax scale
+        if self.mup_enabled and not self.mup_disable_attention_scaling:
+            head_dim = self.d_model // self.n_heads
+            if self.attn_config.get('softmax_scale') is None:
+                self.attn_config = dict(self.attn_config)
+                self.attn_config['softmax_scale'] = 1.0 / float(head_dim)
+
+        # End __init__
+

--- a/llmfoundry/models/mpt/modeling_mpt_mup.py
+++ b/llmfoundry/models/mpt/modeling_mpt_mup.py
@@ -1,0 +1,174 @@
+# Copyright 2024 MosaicML LLM Foundry authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""muP-enabled MPT model."""
+
+from __future__ import annotations
+
+from typing import Any, MutableMapping, Optional, List, Tuple
+
+import torch
+from torch import nn
+
+from .configuration_mpt_mup import MPTMuPConfig
+from .modeling_mpt import MPTModel, MPTForCausalLM, ComposerMPTCausalLM
+from ..layers.mup_embedding import MuPSharedEmbedding
+from omegaconf import DictConfig
+from omegaconf import OmegaConf as om
+from transformers import PreTrainedTokenizerBase
+from composer.metrics import (
+    InContextLearningCodeEvalAccuracy,
+    InContextLearningLMAccuracy,
+    InContextLearningLMExpectedCalibrationError,
+    InContextLearningMCExpectedCalibrationError,
+    InContextLearningMultipleChoiceAccuracy,
+    InContextLearningQAAccuracy,
+)
+from composer.metrics.nlp import LanguageCrossEntropy, LanguagePerplexity
+from composer.models import HuggingFaceModel
+
+
+class MPTMuPModel(MPTModel):
+    config_class = MPTMuPConfig
+
+    def __init__(self, config: MPTMuPConfig):
+        super().__init__(config)
+        if config.mup_enabled:
+            # Begin muP code: scale input embeddings
+            self.wte = MuPSharedEmbedding(config.vocab_size,
+                                          config.d_model,
+                                          device=config.init_device,
+                                          scale=config.mup_input_alpha)
+            if config.init_device != 'meta':
+                self.param_init_fn(self.wte)
+            # End muP code
+        self.mup_cfg = config
+        if self.mup_cfg.mup_enabled:
+            # Begin muP code: reinitialize weights following muP rules
+            for name, param in self.named_parameters():
+                if name.endswith('Wqkv.weight') or name.endswith('fc1_weight'):
+                    nn.init.normal_(
+                        param,
+                        mean=0.0,
+                        std=self.mup_cfg.init_config.get('init_std', 0.02) /
+                        (self.mup_cfg.mup_width_multiplier**0.5),
+                    )
+                elif name.endswith('out_proj.weight') or name.endswith('fc2_weight'):
+                    nn.init.normal_(
+                        param,
+                        mean=0.0,
+                        std=self.mup_cfg.init_config.get('init_std', 0.02) /
+                        ((2 * self.mup_cfg.n_layers * self.mup_cfg.mup_width_multiplier)**0.5),
+                    )
+            # End muP code
+
+    def get_optimizer_param_groups(self, weight_decay: float):
+        """Return parameter groups with muP-specific LR scaling."""
+        param_dict = {n: p for n, p in self.named_parameters() if p.requires_grad}
+        if self.mup_cfg.mup_enabled and not self.mup_cfg.mup_disable_hidden_lr_scaling:
+            # Begin muP code: build parameter groups for muP
+            mup_decay, decay, nodecay = [], [], []
+            for n, p in param_dict.items():
+                if p.dim() >= 2:
+                    if n.endswith('Wqkv.weight') or n.endswith('fc1_weight') or n.endswith('out_proj.weight') or n.endswith('fc2_weight'):
+                        mup_decay.append(p)
+                    else:
+                        decay.append(p)
+                else:
+                    nodecay.append(p)
+            return [
+                {'params': mup_decay, 'weight_decay': weight_decay, 'lr_scale': 1.0 / self.mup_cfg.mup_width_multiplier},
+                {'params': decay, 'weight_decay': weight_decay, 'lr_scale': 1.0},
+                {'params': nodecay, 'weight_decay': 0.0, 'lr_scale': 1.0},
+            ]
+            # End muP code
+        else:
+            decay = [p for n, p in param_dict.items() if p.dim() >= 2]
+            nodecay = [p for n, p in param_dict.items() if p.dim() < 2]
+            return [
+                {'params': decay, 'weight_decay': weight_decay},
+                {'params': nodecay, 'weight_decay': 0.0},
+            ]
+
+    def forward(self, *args: Any, **kwargs: Any):
+        x = super().forward(*args, **kwargs)
+        return x
+
+class MPTMuPForCausalLM(MPTForCausalLM):
+    config_class = MPTMuPConfig
+
+    def __init__(self, config: MPTMuPConfig):
+        super().__init__(config)
+        if not isinstance(self.transformer, MPTMuPModel):
+            self.transformer = MPTMuPModel(config)
+        self.mup_cfg = config
+
+    def forward(self, *args: Any, **kwargs: Any):
+        outputs = super().forward(*args, **kwargs)
+        if self.mup_cfg.mup_enabled:
+            # Begin muP code: scale output logits
+            logits = outputs.logits * (
+                self.mup_cfg.mup_output_alpha / self.mup_cfg.mup_width_multiplier
+            )
+            outputs.logits = logits
+            # End muP code
+        return outputs
+
+    def get_optimizer_param_groups(self, weight_decay: float):
+        return self.transformer.get_optimizer_param_groups(weight_decay)
+
+
+class ComposerMPTMuPCausalLM(HuggingFaceModel):
+    def __init__(self, om_model_config: DictConfig, tokenizer: Optional[PreTrainedTokenizerBase] = None):
+        resolved = om.to_container(om_model_config, resolve=True)
+        hf_config = MPTMuPConfig.from_dict(resolved)
+        model = MPTMuPForCausalLM(hf_config)
+
+        use_train_metrics = om_model_config.get('use_train_metrics', True)
+        train_metrics = [LanguageCrossEntropy(), LanguagePerplexity()] if use_train_metrics else []
+        eval_metrics = [
+            LanguageCrossEntropy(),
+            LanguagePerplexity(),
+            InContextLearningLMAccuracy(),
+            InContextLearningMultipleChoiceAccuracy(),
+            InContextLearningQAAccuracy(),
+            InContextLearningCodeEvalAccuracy(),
+            InContextLearningLMExpectedCalibrationError(),
+            InContextLearningMCExpectedCalibrationError(),
+        ]
+
+        super().__init__(
+            model=model,
+            tokenizer=tokenizer,
+            use_logits=True,
+            metrics=train_metrics,
+            eval_metrics=eval_metrics,
+            shift_labels=True,
+            allow_embedding_resizing=True,
+        )
+
+        self.n_active_params = sum(p.numel() for p in self.parameters())
+
+        loss_fn_config = om_model_config.get('loss_fn', 'fused_crossentropy')
+        if loss_fn_config == 'fused_crossentropy':
+            try:
+                from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss
+
+                self.loss_fn = FusedCrossEntropyLoss(ignore_index=-100)
+            except Exception:
+                raise ValueError(
+                    'Fused Cross Entropy is not installed. Either (1) have a CUDA-compatible GPU '
+                    'and `pip install .[gpu]` if installing from source or '
+                    '`pip install xentropy-cuda-lib@git+https://github.com/HazyResearch/flash-attention.git@v1.0.3#subdirectory=csrc/xentropy` '
+                    'if installing from pypi, or (2) set your config model.loss_fn=torch_crossentropy.'
+                )
+        elif loss_fn_config == 'torch_crossentropy':
+            self.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
+        else:
+            raise ValueError(
+                f'Specified loss_fn={loss_fn_config} not recognized. `loss_fn` must be one of [`fused_crossentropy`, `torch_crossentropy`].'
+            )
+
+    def get_optimizer_param_groups(self, weight_decay: float):
+        """Delegate to underlying model to build param groups."""
+        return self.model.get_optimizer_param_groups(weight_decay)

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -157,16 +157,28 @@ def build_algorithm(name: str, kwargs: Dict[str, Any]) -> Algorithm:
 
 def build_optimizer(model: torch.nn.Module, name: str,
                     optimizer_config: Dict[str, Any]) -> Optimizer:
+    param_groups = None
+    if hasattr(model, 'get_optimizer_param_groups'):
+        # model constructs its own parameter groups (e.g., for muP)
+        weight_decay = optimizer_config.get('weight_decay', 0.0)
+        param_groups = model.get_optimizer_param_groups(weight_decay)
+        optimizer_config = {
+            k: v
+            for k, v in optimizer_config.items() if k != 'weight_decay'
+        }
+    else:
+        param_groups = model.parameters()
+
     if name == 'decoupled_adamw':
-        return DecoupledAdamW(model.parameters(), **optimizer_config)
+        return DecoupledAdamW(param_groups, **optimizer_config)
     elif name == 'decoupled_lionw':
-        return DecoupledLionW(model.parameters(), **optimizer_config)
+        return DecoupledLionW(param_groups, **optimizer_config)
     elif name == 'clip_lion':
-        return DecoupledClipLion(model.parameters(), **optimizer_config)
+        return DecoupledClipLion(param_groups, **optimizer_config)
     elif name == 'adalr_lion':
-        return DecoupledAdaLRLion(model.parameters(), **optimizer_config)
+        return DecoupledAdaLRLion(param_groups, **optimizer_config)
     elif name == 'decoupled_lionw_8b':
-        return DecoupledLionW_8bit(model.parameters(), **optimizer_config)
+        return DecoupledLionW_8bit(param_groups, **optimizer_config)
     else:
         raise ValueError(f'Not sure how to build optimizer: {name}')
 


### PR DESCRIPTION
## Summary
- fix truncated `MPTMuPConfig` file
- expose `get_optimizer_param_groups` in muP model classes
- allow `build_optimizer` to use model-defined parameter groups for custom LR scaling

## Testing
- `pytest -k mup -q` *(fails: ModuleNotFoundError: No module named 'composer')*

------
https://chatgpt.com/codex/tasks/task_e_68484a423ac0833187fe875b608a8028