### PR TITLE
Improve MuP typing

### DIFF
--- a/llmfoundry/callbacks/coord_check.py
+++ b/llmfoundry/callbacks/coord_check.py
@@ -1,10 +1,13 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, Callable
+
 import numpy as np
 import torch
 from composer.core import Callback, State
 from composer.loggers import Logger
+from torch.utils.hooks import RemovableHandle
 
 __all__ = ['CoordCheckLogger']
 
@@ -13,20 +16,27 @@ class CoordCheckLogger(Callback):
     """Log layer activation means for muP coordinate checks."""
 
     def __init__(self) -> None:
-        self.handles = []
+        self.handles: list[RemovableHandle] = []
         self.reset()
 
     def reset(self) -> None:
-        self.stats = {
+        self.stats: dict[str, list[float]] = {
             'token_embedding': [],
             'attn': [],
             'mlp': [],
             'lm_head': [],
         }
 
-    def _hook_factory(self, key: str):
+    def _hook_factory(
+        self,
+        key: str,
+    ) -> Callable[[torch.nn.Module, tuple[Any, ...], torch.Tensor], None]:
 
-        def hook(_module, _inp, out):
+        def hook(
+            _module: torch.nn.Module,
+            _inp: tuple[Any, ...],
+            out: torch.Tensor,
+        ) -> None:
             with torch.no_grad():
                 tensor = out[0] if isinstance(out, tuple) else out
                 if isinstance(tensor, torch.Tensor):
@@ -60,10 +70,10 @@ class CoordCheckLogger(Callback):
             h.remove()
         self.handles = []
 
-    def fit_start(self, state: State, logger: Logger) -> None:  # type: ignore
+    def fit_start(self, state: State, logger: Logger) -> None:
         self._register_hooks(state.model)
 
-    def batch_end(self, state: State, logger: Logger) -> None:  # type: ignore
+    def batch_end(self, state: State, logger: Logger) -> None:
         metrics = {
             f'coord_check/{k}': float(np.mean(v))
             for k, v in self.stats.items()
@@ -73,5 +83,5 @@ class CoordCheckLogger(Callback):
             logger.log_metrics(metrics)
         self.reset()
 
-    def fit_end(self, state: State, logger: Logger) -> None:  # type: ignore
+    def fit_end(self, state: State, logger: Logger) -> None:
         self._remove_hooks()

--- a/llmfoundry/models/mpt/modeling_mpt_mup.py
+++ b/llmfoundry/models/mpt/modeling_mpt_mup.py
@@ -6,22 +6,16 @@
 from __future__ import annotations
 
 import logging
-
-log = logging.getLogger(__name__)
 from typing import Any
 
-import torch
-import torch.nn.functional as F
+log = logging.getLogger(__name__)
+
 from torch import nn
-from transformers.modeling_outputs import (
-    BaseModelOutputWithPast,
-    CausalLMOutputWithPast,
-)
+from transformers.modeling_outputs import BaseModelOutputWithPast
 
 from ..layers.mup_embedding import MuPSharedEmbedding
 from .configuration_mpt_mup import MPTMuPConfig
 from .modeling_mpt import (
-    CROSS_ENTROPY_IGNORE_INDEX,
     ComposerMPTCausalLM,
     MPTForCausalLM,
     MPTModel,
@@ -87,7 +81,11 @@ class MPTMuPModel(MPTModel):
                     log.debug(f'Initialized {name} with muP std: {muP_std:.4f}')
             # End muP code
 
-    def get_optimizer_param_groups(self, weight_decay: float, lr: float):
+    def get_optimizer_param_groups(
+        self,
+        weight_decay: float,
+        lr: float,
+    ) -> list[dict[str, Any]]:
         """Return parameter groups with muP-specific LR scaling."""
         param_dict = {
             n: p for n, p in self.named_parameters() if p.requires_grad
@@ -176,14 +174,22 @@ class MPTMuPForCausalLM(MPTForCausalLM):
             self.transformer = MPTMuPModel(config)
         self.mup_cfg = config
 
-    def get_optimizer_param_groups(self, weight_decay: float, lr: float):
+    def get_optimizer_param_groups(
+        self,
+        weight_decay: float,
+        lr: float,
+    ) -> list[dict[str, Any]]:
         return self.transformer.get_optimizer_param_groups(weight_decay, lr)
 
 
 class ComposerMPTCausalLMWithParamGroups(ComposerMPTCausalLM):
     """Composer wrapper that delegates optimizer param group creation to the underlying model."""
 
-    def get_optimizer_param_groups(self, weight_decay: float, lr: float):
+    def get_optimizer_param_groups(
+        self,
+        weight_decay: float,
+        lr: float,
+    ) -> list[dict[str, Any]]:
         """Delegate to underlying model to build param groups."""
         return self.model.get_optimizer_param_groups(weight_decay, lr)
 

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -5,6 +5,7 @@ import copy
 from typing import Any, Callable
 
 import pytest
+from composer.models import ComposerModel
 from pytest import fixture
 from transformers import PreTrainedTokenizerBase
 
@@ -15,7 +16,10 @@ from llmfoundry.models.mpt.modeling_mpt_mup import \
 from llmfoundry.utils.builders import build_composer_model
 
 
-def _build_model(config: dict[str, Any], tokenizer: PreTrainedTokenizerBase):
+def _build_model(
+    config: dict[str, Any],
+    tokenizer: PreTrainedTokenizerBase,
+) -> ComposerModel:
     name = config.pop('name')
     model = build_composer_model(
         name=name,

--- a/tests/models/test_coord_check.py
+++ b/tests/models/test_coord_check.py
@@ -65,8 +65,8 @@ def _collect_widths(
     build_fn: Callable[..., ComposerMPTCausalLM],
     widths: list[int],
     base_width: int | None = None,
-):
-    vals = []
+) -> list[dict[str, float]]:
+    vals: list[dict[str, float]] = []
     head_size = 16
     for width in widths:
         n_heads = max(1, width // head_size)
@@ -88,7 +88,7 @@ def _collect_widths(
 def test_coord_check_mup_vs_sp(
     build_tiny_mpt: Callable[..., ComposerMPTCausalLM],
     build_tiny_mpt_mup: Callable[..., ComposerMPTCausalLMWithParamGroupsMuP],
-):
+) -> None:
     torch.manual_seed(0)
     widths = [16, 32, 64, 128]
     sp_vals = _collect_widths(build_tiny_mpt, widths)

--- a/tests/models/test_mpt_mup.py
+++ b/tests/models/test_mpt_mup.py
@@ -1,12 +1,16 @@
 # Copyright 2024 MosaicML LLM Foundry authors
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import torch
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from llmfoundry.models.layers.mup_embedding import MuPSharedEmbedding
 from llmfoundry.models.mpt.configuration_mpt_mup import MPTMuPConfig
 from llmfoundry.models.mpt.modeling_mpt import MPTForCausalLM
+from llmfoundry.models.mpt.modeling_mpt_mup import \
+    ComposerMPTCausalLMWithParamGroupsMuP
 from llmfoundry.utils.builders import build_optimizer
 
 
@@ -24,7 +28,9 @@ def dummy_forward(
     return CausalLMOutputWithPast(logits=logits)
 
 
-def test_mup_embedding_and_param_groups(build_tiny_mpt_mup):
+def test_mup_embedding_and_param_groups(
+    build_tiny_mpt_mup: Callable[..., ComposerMPTCausalLMWithParamGroupsMuP],
+) -> None:
     model = build_tiny_mpt_mup(mup_input_alpha=1.5)
     assert isinstance(model.model.transformer.wte, MuPSharedEmbedding)
     assert model.model.transformer.wte.scale == 1.5
@@ -35,7 +41,7 @@ def test_mup_embedding_and_param_groups(build_tiny_mpt_mup):
         'lr'] == 1.0 / model.model.transformer.mup_cfg.mup_width_multiplier
 
 
-def test_mup_softmax_scale():
+def test_mup_softmax_scale() -> None:
     cfg = MPTMuPConfig(
         d_model=32,
         n_heads=4,
@@ -48,7 +54,9 @@ def test_mup_softmax_scale():
     assert cfg.attn_config['softmax_scale'] == 1.0 / float(head_dim)
 
 
-def test_build_optimizer_uses_mup_groups(build_tiny_mpt_mup):
+def test_build_optimizer_uses_mup_groups(
+    build_tiny_mpt_mup: Callable[..., ComposerMPTCausalLMWithParamGroupsMuP],
+) -> None:
     model = build_tiny_mpt_mup(mup_width_multiplier=2.0)
     optim = build_optimizer(
         model.model,


### PR DESCRIPTION
## Summary
- add precise typing for MuP embedding hooks
- type optimizer param groups in MuP models
- refine typing for MuP fixtures and tests

## Testing
- `pyright llmfoundry/callbacks/coord_check.py llmfoundry/models/mpt/modeling_mpt_mup.py tests/fixtures/models.py tests/models/test_coord_check.py tests/models/test_mpt_mup.py`
- `pre-commit run --files llmfoundry/callbacks/coord_check.py llmfoundry/models/mpt/modeling_mpt_mup.py tests/fixtures/models.py tests/models/test_coord_check.py tests/models/test_mpt_mup.py` *(fails: pyright errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68503fed72648331836be3eedabdb3db